### PR TITLE
Fix forwarded message handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+comment_session.session

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ This repository provides a simple Telegram bot that collects comments for a give
    python bot.py
    ```
 
+You can also test the bot against a single post without starting polling:
+   ```bash
+   python bot.py --test https://t.me/CHANNEL/123
+   ```
+
 ## Usage
 
 Send the bot a forwarded post or a link to the post. The bot will respond with collected comments in a structured JSON format.

--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,17 @@
 import os
 import re
 import json
+import argparse
+import asyncio
 from dotenv import load_dotenv
-from telegram import Update
-from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, ContextTypes, filters
+from telegram import Update, MessageOriginChannel
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    MessageHandler,
+    ContextTypes,
+    filters,
+)
 from telethon import TelegramClient
 
 load_dotenv()
@@ -20,6 +28,16 @@ API_ID = int(API_ID)
 client = TelegramClient('comment_session', API_ID, API_HASH)
 
 POST_URL_RE = re.compile(r'https?://t\.me/(c/)?([^/]+)/(?P<msg>\d+)')
+
+
+def parse_post_url(url: str):
+    """Return chat_id and message_id extracted from a post URL."""
+    m = POST_URL_RE.search(url)
+    if not m:
+        return None
+    chat_id = int('-100' + m.group(2)) if m.group(1) else m.group(2)
+    msg_id = int(m.group('msg'))
+    return chat_id, msg_id
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text('Send me a forwarded post or a post link and I will return the comments in JSON.')
@@ -41,18 +59,15 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     chat_id = None
     msg_id = None
 
-    if message.forward_from_chat and message.forward_from_message_id:
-        chat_id = message.forward_from_chat.id
-        msg_id = message.forward_from_message_id
+    if message.forward_origin:
+        origin = message.forward_origin
+        if isinstance(origin, MessageOriginChannel):
+            chat_id = origin.chat.id
+            msg_id = origin.message_id
     elif message.text:
-        m = POST_URL_RE.search(message.text)
-        if m:
-            if m.group(1):
-                # /c/<id>/<msg>
-                chat_id = int('-100' + m.group(2))
-            else:
-                chat_id = m.group(2)
-            msg_id = int(m.group('msg'))
+        result = parse_post_url(message.text)
+        if result:
+            chat_id, msg_id = result
 
     if chat_id and msg_id:
         comments = await collect_comments(chat_id, msg_id)
@@ -64,6 +79,19 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description='Telegram comment collector bot')
+    parser.add_argument('--test', metavar='URL', help='collect comments for the given post and exit')
+    args = parser.parse_args()
+
+    if args.test:
+        result = parse_post_url(args.test)
+        if not result:
+            raise SystemExit('Invalid post URL')
+        chat_id, msg_id = result
+        comments = asyncio.run(collect_comments(chat_id, msg_id))
+        print(json.dumps(comments, ensure_ascii=False, indent=2))
+        return
+
     application = ApplicationBuilder().token(BOT_TOKEN).build()
     application.add_handler(CommandHandler('start', start))
     application.add_handler(MessageHandler(filters.ALL & ~filters.COMMAND, handle_message))


### PR DESCRIPTION
## Summary
- handle forwarded channel posts using `forward_origin`
- add a small CLI with `--test` flag
- update README with test instructions

## Testing
- `python -m py_compile bot.py`
- `python bot.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6850fecf3034832cab709b7a5628a0b1